### PR TITLE
chore: downgrade the 'not changed' log to debug level

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -427,7 +427,7 @@ fn follow_inner(
                             info!(etag, "Successfully activated new configuration");
                         }
                         None => {
-                            info!("Remote not changed");
+                            debug!("Remote not changed");
                         }
                     }
                     match (once, res.is_some()) {


### PR DESCRIPTION
Reduce log clutter by downgrading 'not changed' messages to debug level.

These messages currently flood the logs, obscuring important entries related to changes or issues. Since the service status typically indicates 'running', these frequent log entries are redundant and not critical at the info level.

This adjustment will help focus on more significant log events, enhancing log readability and effectiveness.